### PR TITLE
[docker] : use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/Azure/Dockerfile
+++ b/Azure/Dockerfile
@@ -32,7 +32,7 @@ RUN add-apt-repository universe
 RUN apt-get update && (apt-get -y install bash-completion kubectl openssh-client apache2-utils  jq azure-cli sudo  wget zile byobu ccze powershell)&& \
         kubectl completion bash >/etc/bash_completion.d/kubectl
 # Must use python3 or the fortios ansible modules do not work
-RUN pip3 install ansible
+RUN pip3 --no-cache-dir install ansible
 # see https://galaxy.ansible.com/fortinet/fortios
 RUN ansible-galaxy collection install fortinet.fortios
 RUN export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt ;az extension add --name aks-preview


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>